### PR TITLE
Turn channel into flow

### DIFF
--- a/src/main/kotlin/Core.kt
+++ b/src/main/kotlin/Core.kt
@@ -1,5 +1,6 @@
 package com.seansoper.zebec
 
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
@@ -39,16 +40,14 @@ object Core {
             exitProcess(1)
         }
 
-        val channel = watch.createChannel()
+        val changes = watch.watchChanges()
 
         if (verbose) {
             watch.paths.forEach { println("Watching $it") }
             println("Filtering on files with extensions ${extensions.joinToString()}")
         }
 
-        while (true) {
-            val changed = channel.receive()
-
+        changes.collect { changed ->
             if (verbose) {
                 println("Change detected at ${changed.path}")
             }


### PR DESCRIPTION
Nothing was wrong with the previous implementation as it was, but expanding functionality had a possibility to leak both the `Channel` and the coroutine that was being created from the global scope.

The allows `collect`ion of the data as a stream, and if you wanted to run `watchFiles` outside of a `runBlocking` block it would allow you greater control over cleanup of your coroutine.